### PR TITLE
Replacing all query strings by parameterised sparql string equivalent…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <spring-boot.version>2.1.16.RELEASE</spring-boot.version>
         <jackson.version>2.11.0</jackson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>4.0.3-SNAPSHOT</revision>
+        <revision>4.0.4-SNAPSHOT</revision>
     </properties>
 
     <reporting>


### PR DESCRIPTION
Replacing all query strings by parameterized SPARQL string equivalents, safely substituting variables by given parameters.

This should prevent most SPARQL injection attacks