### PR TITLE
Update buildImages script

### DIFF
--- a/docker/buildImages.sh
+++ b/docker/buildImages.sh
@@ -5,6 +5,7 @@ dos2unix broker-core/*
 # GENERIC IMAGES
 
 mvn -f ../ clean package
+rm broker-core/broker-core-*.jar
 cp ../broker-core/target/broker-core-*.jar broker-core/
 docker build broker-core/ -t registry.gitlab.cc-asp.fraunhofer.de:4567/eis-ids/broker-open/core
 


### PR DESCRIPTION
The new image won't build if the old tar file is still threre.
Add one line to remove the tar file.