### PR TITLE
Feature/retry connection fuseki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change log of the MetaDataBroker open core
+
+## [feature/retryConnectionFuseki] - 12.05.2022
+- Retry connection to Fuseki
+  - If the property sparqlUrl of the `RepositoryFacade` is not an empty string of set to null, the broker assumes that an external 
+  Fuseki server should be used for persistence. So it will throw an exception if it in unable to establish a valid connection after
+  three retries. The property can be set via `sparql.url` in the `application.propertier`.
+  - Changed the member functions `getNewReadOnlyConnectionToFuseki` and `getNewWritableConnection` of the `RespositoryFacade`
+  to check the existence of a valid connection to the fuseki server.
+  - The broker tries to establish the connection three time in a row. In between it waits for 5 seconds. This is not 
+  parameterizable. It is hard coded.
+  - If the property `sparqlUrl` of the `RepositoryFacade` is set to null or is empty an in-mermory db is created and used.  
+  - Testing: 
+    1. Without a Fuseki server running -> QueryHttpException was thrown as expected
+    2. With a Fuseki server running -> connection established and broker initializing of the Fuseki

--- a/open-index-common/src/main/java/de/fraunhofer/iais/eis/ids/index/common/persistence/RepositoryFacade.java
+++ b/open-index-common/src/main/java/de/fraunhofer/iais/eis/ids/index/common/persistence/RepositoryFacade.java
@@ -142,13 +142,36 @@ public class RepositoryFacade {
     public RDFConnection getNewWritableConnection()
     {
         if(sparqlUrl != null && !sparqlUrl.isEmpty()) {
-            return RDFConnectionFactory.connectFuseki(sparqlUrl);
-            //return RDFConnectionFactory.connectFuseki(sparqlUrl);
+            String url = sparqlUrl + (sparqlUrl.endsWith("/")? "" : "/") + "sparql";
+            Integer counter=0;
+            while (counter<3) {
+                try{
+                    logger.info("Trying to establish a connection to Fuseki server with url " + sparqlUrl);
+                    RDFConnection connection = RDFConnectionFactory.connectFuseki(sparqlUrl);
+                    return connection;
+                }
+                catch (QueryExceptionHTTP e) {
+                    logger.info("unable to establish a connection to Fuseki server with url " + url);
+                    counter += 1;
+                    if (counter <3) {
+                        try {
+                            wait(10000);
+                        } catch (InterruptedException ex) {
+                            ex.printStackTrace();
+                        }
+                    } else {
+                        logger.info("stop trying to establish connection ");
+                        throw e;
+                    }
+                }
+            }
+
         } else
         if(dataset == null)
         {
             dataset = DatasetFactory.create();
         }
+
         return RDFConnectionFactory.connect(dataset);
     }
 


### PR DESCRIPTION
## [feature/retryConnectionFuseki] - 12.05.2022
- Retry connection to Fuseki
  - If the property sparqlUrl of the `RepositoryFacade` is not an empty string of set to null, the broker assumes that an external 
  Fuseki server should be used for persistence. So it will throw an exception if it in unable to establish a valid connection after
  three retries. The property can be set via `sparql.url` in the `application.propertier`.
  - Changed the member functions `getNewReadOnlyConnectionToFuseki` and `getNewWritableConnection` of the `RespositoryFacade`
  to check the existence of a valid connection to the fuseki server.
  - The broker tries to establish the connection three time in a row. In between it waits for 5 seconds. This is not 
  parameterizable. It is hard coded.
  - If the property `sparqlUrl` of the `RepositoryFacade` is set to null or is empty an in-mermory db is created and used.  
  - Testing: 
    1. Without a Fuseki server running -> QueryHttpException was thrown as expected
    2. With a Fuseki server running -> connection established and broker initializing of the Fuseki